### PR TITLE
build(docker): bump node to v14.13.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build environment
-FROM --platform=$BUILDPLATFORM node:14.11.0-alpine3.12 as build-stage
+FROM --platform=$BUILDPLATFORM node:14.13.1-alpine3.12 as build-stage
 RUN mkdir /app && chown -R node:node /app
 WORKDIR /app
 RUN apk add --no-cache python3 make g++

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,5 +1,5 @@
 # build environment
-FROM --platform=$BUILDPLATFORM node:14.11.0-alpine3.12 as build-stage
+FROM --platform=$BUILDPLATFORM node:14.13.1-alpine3.12 as build-stage
 RUN mkdir /app && chown -R node:node /app
 WORKDIR /app
 RUN apk add --no-cache python3 make g++


### PR DESCRIPTION
Dependabot missed the build stages so this bumps them manually