### PR TITLE
build(docker): use tini for init

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,8 @@ FROM node:14.13.1-alpine3.12 as production-stage
 RUN mkdir /app && chown -R node:node /app
 WORKDIR /app
 RUN apk add --no-cache tini
+
+USER node
 COPY --chown=node:node server.js .
 COPY --chown=node:node config config
 COPY --chown=node:node --from=dependency-stage /app/node_modules node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,9 +26,11 @@ RUN npm prune --production
 FROM node:14.13.1-alpine3.12 as production-stage
 RUN mkdir /app && chown -R node:node /app
 WORKDIR /app
+RUN apk add --no-cache tini
 COPY --chown=node:node server.js .
 COPY --chown=node:node config config
 COPY --chown=node:node --from=dependency-stage /app/node_modules node_modules
 COPY --chown=node:node --from=build-stage /app/dist dist
 
-ENTRYPOINT ["/app/server.js"]
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD ["/app/server.js"]

--- a/server.js
+++ b/server.js
@@ -4,15 +4,6 @@ const syncloungeServer = require('syncloungeserver');
 const path = require('path');
 const config = require('./config');
 
-// Using a single function to handle multiple signals
-const handle = (signal) => {
-  console.log(`Received ${signal}. Exiting`);
-  process.exit(0);
-};
-
-process.on('SIGINT', handle);
-process.on('SIGTERM', handle);
-
 const blockList = Object.keys(syncloungeServer.defaultConfig);
 const appConfig = config.get(null, blockList);
 console.log(appConfig);


### PR DESCRIPTION
Use tini for init rather than manually writing signal handlers