### PR TITLE
ci(release): wait to checkout until previous release done

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,13 +50,18 @@ jobs:
       release-version-minor: ${{ steps.release.outputs.release-version-minor }}
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2.3.3
-
       - name: Setup Node.js
         uses: actions/setup-node@v2.1.2
         with:
           node-version: 14
+
+      - name: Turnstyle
+        uses: softprops/turnstyle@v0.1.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout
+        uses: actions/checkout@v2.3.3
 
       - name: Cache Node.js modules
         id: cache
@@ -74,11 +79,6 @@ jobs:
         run: npm ci
         env:
           SKIP_BUILD: true
-
-      - name: Turnstyle
-        uses: softprops/turnstyle@v0.1.3
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Semantic release
         id: release


### PR DESCRIPTION
Wait to run checkout until previous releases finish in order to have the latest tags in the checked out repo. This is important because semantic release determines the next version based on the tags in the current repo.