### PR TITLE
refactor(router): add default route

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -20,6 +20,13 @@ export default new Router({
     },
 
     {
+      path: '*',
+      redirect: {
+        name: 'RoomCreation',
+      },
+    },
+
+    {
       path: '/signin',
       name: 'SignIn',
       component: () => import('@/views/SignIn.vue'),


### PR DESCRIPTION
Add a default route that redirects to RoomCreation. Any urls that don't match any of the other routes will hit this. Without this, going to a non existent url will just show an empty router-view which isn't helpful.