### PR TITLE
fix(autojoin): use store instead of this

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -32,7 +32,7 @@ router.beforeEach(async (to, from, next) => {
     if (store.getters.GET_CONFIG.autojoin) {
       next({
         name: 'RoomJoin',
-        params: this.GET_CONFIG.autojoin,
+        params: store.getters.GET_CONFIG.autojoin,
       });
     }
   }


### PR DESCRIPTION
Tested with both autojoin server specified and unspecified/empty string