### PR TITLE
feat(subtitles): add force burn subtitles setting

### DIFF
--- a/src/components/TheSettingsDialog.vue
+++ b/src/components/TheSettingsDialog.vue
@@ -52,6 +52,27 @@
           </v-list-item-action>
         </v-list-item>
 
+        <v-list-item
+          three-line
+          @click="SET_FORCE_BURN_SUBTITLES(!forceBurnSubtitles)"
+        >
+          <v-list-item-content>
+            <v-list-item-title>Force Burn Subtitles</v-list-item-title>
+            <v-list-item-subtitle>
+              Force Plex to burn all subtitles.
+            </v-list-item-subtitle>
+          </v-list-item-content>
+
+          <v-list-item-action>
+            <v-switch
+              hide-details
+              :input-value="forceBurnSubtitles"
+              @change="SET_FORCE_BURN_SUBTITLES"
+              @click.stop
+            />
+          </v-list-item-action>
+        </v-list-item>
+
         <v-list-item @click="streamingProtocolSelectOpen=!streamingProtocolSelectOpen">
           <v-list-item-content>
             <v-list-item-title>Streaming Protocol</v-list-item-title>
@@ -292,7 +313,9 @@
 </template>
 
 <script>
-import { mapActions, mapGetters, mapMutations } from 'vuex';
+import {
+  mapActions, mapGetters, mapMutations, mapState,
+} from 'vuex';
 import { streamingProtocols } from '@/utils/streamingprotocols';
 
 export default {
@@ -339,6 +362,10 @@ export default {
       'GET_PLEX_USER',
     ]),
 
+    ...mapState('slplayer', [
+      'forceBurnSubtitles',
+    ]),
+
     username() {
       return this.GET_PLEX_USER?.username;
     },
@@ -383,6 +410,7 @@ export default {
 
     ...mapMutations('slplayer', [
       'SET_STREAMING_PROTOCOL',
+      'SET_FORCE_BURN_SUBTITLES',
     ]),
 
     ...mapMutations('synclounge', [

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -30,6 +30,7 @@ const persistedState = createPersistedState({
     'synclounge.areNotificationsEnabled',
     'synclounge.areSoundNotificationsEnabled',
 
+    'slplayer.forceBurnSubtitles',
     'slplayer.subtitleSize',
     'slplayer.subtitlePosition',
     'slplayer.subtitleColor',

--- a/src/store/modules/slplayer/getters.js
+++ b/src/store/modules/slplayer/getters.js
@@ -222,7 +222,8 @@ export default {
       : base;
   },
 
-  SHOULD_FORCE_BURN_SUBTITLES: (state, getters) => getters.IS_IN_PICTURE_IN_PICTURE,
+  SHOULD_FORCE_BURN_SUBTITLES: (state, getters) => getters.IS_IN_PICTURE_IN_PICTURE
+    || state.forceBurnSubtitles,
 
   GET_SUBTITLE_PARAMS: (state, getters) => {
     if (!getters.GET_SELECTED_SUBTITLE_STREAM || getters.CAN_DIRECT_PLAY

--- a/src/store/modules/slplayer/mutations.js
+++ b/src/store/modules/slplayer/mutations.js
@@ -106,4 +106,8 @@ export default {
   SET_FORCE_TRANSCODE_RETRY: (state, force) => {
     state.forceTranscodeRetry = force;
   },
+
+  SET_FORCE_BURN_SUBTITLES: (state, forceBurn) => {
+    state.forceBurnSubtitles = forceBurn;
+  },
 };

--- a/src/store/modules/slplayer/state.js
+++ b/src/store/modules/slplayer/state.js
@@ -33,6 +33,7 @@ const state = () => ({
   subtitleOffset: 0,
   streamingProtocol: 'dash',
   forceTranscodeRetry: false,
+  forceBurnSubtitles: false,
 });
 
 export default state;

--- a/src/views/WebPlayer.vue
+++ b/src/views/WebPlayer.vue
@@ -169,7 +169,7 @@
 
 <script>
 
-import { mapActions, mapGetters } from 'vuex';
+import { mapActions, mapGetters, mapState } from 'vuex';
 
 import initialize from '@/player/init';
 import { getControlsOffset } from '@/player';
@@ -203,6 +203,7 @@ export default {
       'GET_SECONDARY_TITLE',
       'ARE_PLAYER_CONTROLS_SHOWN',
       'GET_PLAYER_STATE',
+      'IS_USING_NATIVE_SUBTITLES',
     ]),
 
     ...mapGetters('synclounge', [
@@ -220,6 +221,10 @@ export default {
 
     ...mapGetters([
       'GET_CONFIG',
+    ]),
+
+    ...mapState('slplayer', [
+      'forceBurnSubtitles',
     ]),
 
     playerConfig() {
@@ -290,6 +295,12 @@ export default {
       },
       immediate: true,
     },
+
+    async forceBurnSubtitles(forceBurn) {
+      if (forceBurn && this.IS_USING_NATIVE_SUBTITLES) {
+        await this.UPDATE_PLAYER_SRC_AND_KEEP_TIME();
+      }
+    },
   },
 
   async mounted() {
@@ -338,6 +349,7 @@ export default {
       'SEND_PARTY_PLAY_PAUSE',
       'SKIP_INTRO',
       'RERENDER_SUBTITLE_CONTAINER',
+      'UPDATE_PLAYER_SRC_AND_KEEP_TIME',
     ]),
 
     ...mapActions('synclounge', [


### PR DESCRIPTION
The setting can be found in the settings dialog which can be opened from
the left sidebar.

Closes https://github.com/synclounge/synclounge/issues/246