### PR TITLE
ci(release): disable docker readme update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,12 +215,12 @@ jobs:
           build-args: |
             VERSION=${{ needs.release-semantic.outputs.release-version }}
 
-      - name: Update repo description
-        uses: peter-evans/dockerhub-description@v2.4.1
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: ${{ matrix.docker-image }}
+      # - name: Update repo description
+      #   uses: peter-evans/dockerhub-description@v2.4.1
+      #   with:
+      #     username: ${{ secrets.DOCKER_USERNAME }}
+      #     password: ${{ secrets.DOCKER_PASSWORD }}
+      #     repository: ${{ matrix.docker-image }}
 
       - name: Inspect
         run: |


### PR DESCRIPTION
Disable the readme update because it is causing the release to fail. I don't know why this action isn't working on this repository